### PR TITLE
Fix window close warning message type and streamline course conversion handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2]
+
+### Fixed
+- Popup page "Don't close the window" message color.
+- Options page "Course names updated" message translation.
+
 ## [1.4.1]
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "__MSG_extension_name__",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "__MSG_extension_description__",
     "default_locale": "en",
     "icons": {

--- a/options/options.js
+++ b/options/options.js
@@ -790,15 +790,8 @@ document.addEventListener('DOMContentLoaded', function () {
             }
 
             if (coursesToConvert.length === 0) {
-                const langNameEng = targetLang === 'he' ? 'Hebrew' : 'English';
-                const langNameHeb = targetLang === 'he' ? 'עברית' : 'אנגלית';
                 if (courseExists) {
-                    await chrome.storage.local.set({ course_name_preferred_lang: targetLang });
-                    if (targetLang === 'he') {
-                        handleMessages(getMessage('course_names_updated') + langNameHeb, null, false);
-                    } else {
-                        handleMessages(getMessage('course_names_updated') + langNameEng, null, false);
-                    }
+                    courseConversionCompleteMessage(targetLang);
                 } else {
                     handleMessages(getMessage('no_courses_to_convert'), null, false);
                 }
@@ -903,7 +896,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
             // Check if all courses are converted
             if (convertedCount >= storage.total_courses_to_convert) {
-                handleMessages(getMessage('all_courses_processed'), null, false);
+                courseConversionCompleteMessage(storage.course_name_preferred_lang);
                 await chrome.storage.local.remove(['converting_courses', 'total_courses_to_convert', 'converted_courses']);
                 setConvertingState(false);
             }
@@ -935,6 +928,17 @@ document.addEventListener('DOMContentLoaded', function () {
             chrome.storage.local.remove('checkedUserDetails');
         }
     });
+
+    async function courseConversionCompleteMessage(targetLang) {
+        const langNameEng = targetLang === 'he' ? 'Hebrew' : 'English';
+        const langNameHeb = targetLang === 'he' ? 'עברית' : 'אנגלית';
+        await chrome.storage.local.set({ course_name_preferred_lang: targetLang });
+        if (displayLang === 'he') {
+            handleMessages(getMessage('course_names_updated') + langNameHeb, null, false);
+        } else {
+            handleMessages(getMessage('course_names_updated') + " " + langNameEng, null, false);
+        }
+    }
 
     function updateConversionButtonsVisibility() {
         const coursesList = document.getElementById("courses_list");
@@ -1211,7 +1215,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
             // Check if all courses are converted
             if (convertedCount >= storage.total_courses_to_convert) {
-                handleMessages(getMessage('all_courses_processed'), null, false);
+                courseConversionCompleteMessage(storage.course_name_preferred_lang);
                 setConvertingState(false);
                 await chrome.storage.local.remove(['converting_courses', 'total_courses_to_convert', 'converted_courses']);
             }

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -442,7 +442,7 @@ document.addEventListener("DOMContentLoaded", function () {
             button.classList.add("loading");
             button.disabled = true;
 
-            sendMessage(getMessage('dont_close_window'), 'info');
+            sendMessage(getMessage('dont_close_window'), 'other');
 
             const loadingPaths = [
                 '<path d="M1 11a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1zm5-4a1"/>',
@@ -463,7 +463,7 @@ document.addEventListener("DOMContentLoaded", function () {
             button.classList.add("loading");
             button.disabled = true;
 
-            sendMessage(getMessage('dont_close_window'), 'info');
+            sendMessage(getMessage('dont_close_window'), 'other');
 
             const loadingPaths = [
                 'transform = "matrix(0.96592611, 0.25881901, -0.25881901, 0.96592611, 7.9e-7, 5.3e-7)"', // 15 degrees


### PR DESCRIPTION
Change the message type for the window close warning from 'info' to 'other' and improve the messaging and handling for course conversion. Update the version to 1.4.2 and document the changes in the changelog.