### PR TITLE
Update version to 1.5.2 and enhance user interface

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -83,16 +83,16 @@ jobs:
           mkdir -p build
           zip -r build/BGU.Scout.zip . -x "*.git*" "*.github*" "*.idea*" "*.vscode*" "Screenshots/*" "build/*" "*.DS_Store" "*.md" "svg-assets/*"
 
-      # - name: Upload to Chrome Web Store
-      #   if: steps.check_tag.outputs.exists == 'false'
-      #   uses: mnao305/chrome-extension-upload@v5.0.0
-      #   with:
-      #     file-path: build/BGU.Scout.zip
-      #     extension-id: ${{ secrets.CHROME_WEB_STORE_APP_ID }}
-      #     client-id: ${{ secrets.CHROME_WEB_STORE_CLIENT_ID }}
-      #     client-secret: ${{ secrets.CHROME_WEB_STORE_CLIENT_SECRET }}
-      #     refresh-token: ${{ secrets.CHROME_WEB_STORE_REFRESH_TOKEN }}
-      #     publish: true
+      - name: Upload to Chrome Web Store
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: mnao305/chrome-extension-upload@v5.0.0
+        with:
+          file-path: build/BGU.Scout.zip
+          extension-id: ${{ secrets.CHROME_WEB_STORE_APP_ID }}
+          client-id: ${{ secrets.CHROME_WEB_STORE_CLIENT_ID }}
+          client-secret: ${{ secrets.CHROME_WEB_STORE_CLIENT_SECRET }}
+          refresh-token: ${{ secrets.CHROME_WEB_STORE_REFRESH_TOKEN }}
+          publish: true
 
       - name: Create Release
         if: steps.check_tag.outputs.exists == 'false'

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 .idea/
 .hintrc
+.github/copilot-instructions.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2]
+
+### Fixed
+- In options page, pointer cursor on hover for switch labels.
+
+
 ## [1.5.1]
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "__MSG_extension_name__",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "__MSG_extension_description__",
     "default_locale": "en",
     "icons": {

--- a/options/options.css
+++ b/options/options.css
@@ -380,6 +380,10 @@ select:hover {
     animation: pulse 1.5s infinite;
 }
 
+label.switch_label:hover {
+    cursor: pointer;
+}
+
 @keyframes pulse {
     0%, 100% { opacity: 0.6; }
     50% { opacity: 0.8; }

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -28,9 +28,9 @@
             <fieldset class="form-fieldset year-semester-fieldset">
                 <legend data-i18n="year_span">Year Span</legend>
                 <div class="year_range">
-                    <input type="number" min="1970" max="2025" id="start_year" aria-label="Start Year">
+                    <input type="number" min="1970" id="start_year" aria-label="Start Year">
                     <span class="year-hyphen">-</span>
-                    <input type="number" min="1970" max="2025" id="end_year" aria-label="End Year">
+                    <input type="number" min="1970" id="end_year" aria-label="End Year">
                 </div>
             </fieldset>
             <fieldset class="form-fieldset">

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -11,6 +11,10 @@ document.addEventListener("DOMContentLoaded", function () {
     const endYearInput = document.getElementById("end_year");
     const mainContainer = document.querySelector(".container");
 
+    const currentYear = new Date().getFullYear();
+    startYearInput.max = currentYear;
+    endYearInput.max = currentYear;
+
     // Multiple selection elements (checkboxes)
     const semesterCheckboxContainer = document.getElementById("semester_checkbox");
     const examCheckboxContainer = document.getElementById("exam_checkbox");


### PR DESCRIPTION
Update the version number in the manifest to 1.5.2, restore the upload step in the release workflow, and improve the user interface by adding a pointer cursor on hover for switch labels. Additionally, set maximum year inputs dynamically based on the current year and add GitHub Copilot instructions to the .gitignore file.