### PR TITLE
Fix Moodle course retrieval and cleanup logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.4]
+
+### Fixed
+- Moodle course number retrieval, which broke once the course number was no longer part of the page HTML. It is now read from the course data in Moodle's web service responses.
+- Course name cleanup no longer strips a trailing "s" and the number after it, so names like "Data Systems 2" keep their number.
+
 ## [1.5.3]
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,10 @@
 {
     "manifest_version": 3,
     "name": "__MSG_extension_name__",
-    "version": "1.5.3",
+    "version": "1.5.4",
     "description": "__MSG_extension_description__",
     "default_locale": "en",
+    "minimum_chrome_version": "111",
     "icons": {
         "16": "extension-icons/icon-16.png",
         "32": "extension-icons/icon-32.png",
@@ -38,6 +39,17 @@
                 "scripts/bgu4u22-content.js"
             ],
             "run_at": "document_idle",
+            "all_frames": true
+        },
+        {
+            "matches": [
+                "https://moodle.bgu.ac.il/moodle/my/*"
+            ],
+            "js": [
+                "scripts/moodle-ajax-hook.js"
+            ],
+            "run_at": "document_start",
+            "world": "MAIN",
             "all_frames": true
         },
         {

--- a/scripts/moodle-ajax-hook.js
+++ b/scripts/moodle-ajax-hook.js
@@ -1,0 +1,125 @@
+"use strict";
+
+// Runs in the page's own JavaScript context (MAIN world) so it can observe the
+// AJAX traffic Moodle uses to build the dashboard. The course number is no
+// longer rendered into the HTML - it only arrives as the `idnumber` /
+// `shortname` of the course objects inside /lib/ajax/service.php responses
+// (e.g. "202150610120262" -> 202.1.5061).
+//
+// Whatever is picked up is written into a JSON <script> element so that
+// scripts/moodle-content.js (isolated world) can read it, no matter which of
+// the two scripts happens to run first.
+(function () {
+    const SERVICE_PATH = '/lib/ajax/service.php';
+    const STORE_ID = 'bgu-scout-moodle-course-data';
+    const EVENT_NAME = 'bgu-scout:moodle-course-data';
+    const MAX_DEPTH = 12;
+
+    if (window.__bguScoutMoodleHookInstalled) {
+        return;
+    }
+    window.__bguScoutMoodleHookInstalled = true;
+
+    const coursesById = new Map();
+
+    function isServiceRequest(url) {
+        return typeof url === 'string' && url.indexOf(SERVICE_PATH) !== -1;
+    }
+
+    // The course objects are nested at different depths depending on which web
+    // service answered (calendar events, course overview, ...), so just walk the
+    // whole payload and pick up anything that looks like a course.
+    function collectCourses(node, found, depth) {
+        if (!node || typeof node !== 'object' || depth > MAX_DEPTH) {
+            return;
+        }
+
+        if (Array.isArray(node)) {
+            node.forEach(item => collectCourses(item, found, depth + 1));
+            return;
+        }
+
+        const idnumber = node.idnumber || node.shortname;
+        if (node.id != null && typeof idnumber === 'string' && typeof node.fullname === 'string') {
+            found.push({
+                id: String(node.id),
+                idnumber: idnumber,
+                fullname: node.fullname
+            });
+        }
+
+        Object.keys(node).forEach(key => collectCourses(node[key], found, depth + 1));
+    }
+
+    function storeCourses(payload) {
+        const found = [];
+        collectCourses(payload, found, 0);
+
+        let changed = false;
+        found.forEach(course => {
+            const known = coursesById.get(course.id);
+            if (!known || known.idnumber !== course.idnumber || known.fullname !== course.fullname) {
+                coursesById.set(course.id, course);
+                changed = true;
+            }
+        });
+
+        if (!changed) {
+            return;
+        }
+
+        let store = document.getElementById(STORE_ID);
+        if (!store) {
+            store = document.createElement('script');
+            store.type = 'application/json';
+            store.id = STORE_ID;
+            (document.head || document.documentElement).appendChild(store);
+        }
+        store.textContent = JSON.stringify(Array.from(coursesById.values()));
+        document.dispatchEvent(new CustomEvent(EVENT_NAME));
+    }
+
+    const originalFetch = window.fetch;
+    if (typeof originalFetch === 'function') {
+        window.fetch = function (...args) {
+            const request = originalFetch.apply(this, args);
+            try {
+                const input = args[0];
+                const url = (input && typeof input === 'object' && input.url) ? input.url : String(input);
+                if (isServiceRequest(url)) {
+                    request.then(response => response.clone().json())
+                        .then(storeCourses)
+                        .catch(() => { /* not a JSON service response, ignore */ });
+                }
+            } catch (error) {
+                // Never let the hook break the page's own request.
+            }
+            return request;
+        };
+    }
+
+    const originalOpen = XMLHttpRequest.prototype.open;
+    const originalSend = XMLHttpRequest.prototype.send;
+
+    XMLHttpRequest.prototype.open = function (method, url, ...rest) {
+        this.__bguScoutUrl = typeof url === 'string' ? url : String(url);
+        return originalOpen.call(this, method, url, ...rest);
+    };
+
+    XMLHttpRequest.prototype.send = function (...args) {
+        if (isServiceRequest(this.__bguScoutUrl)) {
+            this.addEventListener('load', function () {
+                try {
+                    if (this.responseType === 'json') {
+                        storeCourses(this.response);
+                    } else if (!this.responseType || this.responseType === 'text') {
+                        storeCourses(JSON.parse(this.responseText));
+                    }
+                } catch (error) {
+                    // Not a JSON service response, ignore.
+                }
+            });
+        }
+        return originalSend.apply(this, args);
+    };
+})();

--- a/scripts/moodle-content.js
+++ b/scripts/moodle-content.js
@@ -2,92 +2,114 @@
 
 console.log('###Moodle content script loaded###');
 
-// Initialize based on document state
+// Filled in by scripts/moodle-ajax-hook.js, which runs in the page context and
+// taps Moodle's /lib/ajax/service.php responses. The course number is no longer
+// part of the served HTML, so the course objects in those responses are the only
+// place left to read it from.
+const COURSE_DATA_STORE_ID = 'bgu-scout-moodle-course-data';
+const COURSE_DATA_EVENT = 'bgu-scout:moodle-course-data';
+const SAVE_DEBOUNCE_MS = 300;
+
+let saveTimeout = null;
+
 chrome.storage.local.get(['auto_add_moodle_courses'], function (result) {
     if (result.auto_add_moodle_courses) {
-        if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', initializeCourseList);
-        } else {
-            initializeCourseList();
-        }
+        // Responses trickle in as the dashboard renders, so re-read on every update.
+        document.addEventListener(COURSE_DATA_EVENT, scheduleSave);
+        scheduleSave();
     }
 });
 
-function initializeCourseList() {
-    const observer = new MutationObserver((mutations, obs) => {
-        const courseList2 = document.querySelector("#page-container-2 > div > div");
-        const courseList3 = document.querySelector("#page-container-3 > div > div")
-        checkForCourseList(courseList2, obs);
-        checkForCourseList(courseList3, obs);
-    });
-
-    // Start observing
-    observer.observe(document.body, {
-        childList: true,
-        subtree: true
-    });
+function scheduleSave() {
+    clearTimeout(saveTimeout);
+    saveTimeout = setTimeout(saveDiscoveredCourses, SAVE_DEBOUNCE_MS);
 }
 
-function checkForCourseList(courseList, obs) {
-    if (courseList) {
-        const courseNumberList = document.querySelector("#calendar-course-filter-1");
-
-        obs.disconnect();
-
-        let courseItems = courseList.querySelectorAll('.card');
-        const coursesToSave = {};
-        
-        courseItems.forEach(courseItem => {
-            let courseName = (courseItem.innerText
-                .trim()
-                .match(/(.*)\n/)?.[0]
-                ?.replace(/\n/g, '') || courseItem.innerText.trim())
-
-            // Apply cleanup to course name
-            courseName = trimCourseName(courseName);
-
-            const courseLink = courseItem.querySelector('a').href;
-            const courseCode = courseLink.match(/id=(\d+)/)[1];
-            let courseNumber = courseNumberList.querySelector(`option[value="${courseCode}"]`).innerText.substring(0, 8);
-            courseNumber = courseNumber.substring(0, 3) + '.' + courseNumber[3] + '.' + courseNumber.substring(4, 8);
-            coursesToSave[courseNumber] = courseName;
-        });
-
-        chrome.storage.local.get(['saved_courses', 'course_name_preferred_lang'], function (result) {
-            const savedCourses = result.saved_courses || {};
-            const preferredLang = result.course_name_preferred_lang || (navigator.language.startsWith('he') ? 'he' : 'en');
-            
-            for (const courseNumber in coursesToSave) {
-                if (savedCourses[courseNumber]) {
-                    delete coursesToSave[courseNumber];
-                }
-            }
-            
-            // Convert to new format with language detection
-            const newSavedCourses = { ...savedCourses };
-            for (const courseNumber in coursesToSave) {
-                const courseName = coursesToSave[courseNumber];
-                const detectedLang = detectLanguage(courseName);
-                
-                newSavedCourses[courseNumber] = {
-                    names: {
-                        [detectedLang]: courseName
-                    }
-                };
-            }
-            
-            chrome.storage.local.set({ 'saved_courses': newSavedCourses }, function () {
-                console.log('Courses saved:', newSavedCourses);
-            });
-        });
+function readCourseData() {
+    const store = document.getElementById(COURSE_DATA_STORE_ID);
+    if (!store || !store.textContent) {
+        return [];
     }
+
+    try {
+        return JSON.parse(store.textContent);
+    } catch (error) {
+        console.error('Failed to read Moodle course data:', error);
+        return [];
+    }
+}
+
+// "202150610120262" -> "202.1.5061"
+function parseCourseNumber(idnumber) {
+    const digits = String(idnumber ?? '').replace(/\D/g, '');
+    if (digits.length < 8) {
+        return null;
+    }
+
+    return `${digits.substring(0, 3)}.${digits[3]}.${digits.substring(4, 8)}`;
+}
+
+function saveDiscoveredCourses() {
+    const coursesToSave = {};
+
+    readCourseData().forEach(course => {
+        const courseNumber = parseCourseNumber(course.idnumber);
+        if (!courseNumber) {
+            return;
+        }
+
+        const courseName = trimCourseName((course.fullname || '').trim());
+        if (!courseName) {
+            return;
+        }
+
+        coursesToSave[courseNumber] = courseName;
+    });
+
+    if (Object.keys(coursesToSave).length === 0) {
+        return;
+    }
+
+    chrome.storage.local.get(['saved_courses', 'course_name_preferred_lang'], function (result) {
+        const savedCourses = result.saved_courses || {};
+        const preferredLang = result.course_name_preferred_lang || (navigator.language.startsWith('he') ? 'he' : 'en');
+
+        for (const courseNumber in coursesToSave) {
+            if (savedCourses[courseNumber]) {
+                delete coursesToSave[courseNumber];
+            }
+        }
+
+        if (Object.keys(coursesToSave).length === 0) {
+            return;
+        }
+
+        // Convert to new format with language detection
+        const newSavedCourses = { ...savedCourses };
+        for (const courseNumber in coursesToSave) {
+            const courseName = coursesToSave[courseNumber];
+            const detectedLang = detectLanguage(courseName);
+
+            newSavedCourses[courseNumber] = {
+                names: {
+                    [detectedLang]: courseName
+                }
+            };
+        }
+
+        chrome.storage.local.set({ 'saved_courses': newSavedCourses }, function () {
+            console.log('Courses saved:', newSavedCourses);
+        });
+    });
 }
 
 function trimCourseName(courseName) {
     // First pass: Handle semester indicators with numbers
     courseName = courseName
         // Handle semester indicators: "סמ 1", "סמ2", "S 2", "S2", etc.
-        .replace(/\s*(סמ|S|sem|semester|סמסטר)\s*[0-9]+\s*/gi, ' ')
+        // The indicator has to stand on its own - without the boundary guards the
+        // trailing "s" of a name like "Data Systems 2" reads as a semester marker.
+        .replace(/(?<![\p{L}\p{N}_])(סמסטר|סמ|semester|sem|s)\s*[0-9]+(?![\p{L}\p{N}_])/giu, ' ')
 
         // Handle year ranges like "2023-2024"
         .replace(/\s*\d{4}-\d{4}\s*/g, ' ')


### PR DESCRIPTION
Update the logic for retrieving Moodle course numbers to accommodate changes in the HTML structure. Adjust course name cleanup to preserve trailing numbers.